### PR TITLE
[symfony-toggle#44] update dependency constraints to ^0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,14 @@
     ],
     "require": {
         "php": "^7.4|^8.0|^8.1|^8.2",
-        "pheature/toggle-core": "^0.5",
-        "pheature/toggle-model": "^0.5"
+        "pheature/toggle-model": "^0.7"
     },
     "require-dev": {
         "icanhazstring/composer-unused": "^0.8",
-        "pheature/dbal-toggle": "^0.5",
-        "pheature/inmemory-toggle": "^0.5",
-        "pheature/php-sdk": "^0.5",
-        "pheature/toggle-crud": "^0.5",
+        "pheature/dbal-toggle": "^0.7",
+        "pheature/inmemory-toggle": "^0.7",
+        "pheature/php-sdk": "^0.7",
+        "pheature/toggle-crud": "^0.7",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpro/grumphp": "^1.0",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
Related to https://github.com/pheature-flags/symfony-toggle/issues/44